### PR TITLE
Fix row iteration in message sending loop

### DIFF
--- a/BotSharks/Form1.cs
+++ b/BotSharks/Form1.cs
@@ -128,7 +128,7 @@ namespace BotSharks
         {
             if (txtMensaje.Text.Length <= 0)
                 return;
-            for (int percentProgress = 0; percentProgress <= dataGridView.RowCount; ++percentProgress)
+            for (int percentProgress = 0; percentProgress < dataGridView.RowCount; ++percentProgress)
             {
                 if (Mdl_JAAS.bw_jaas.CancellationPending)
                 {


### PR DESCRIPTION
## Summary
- fix iteration bug in `procesoEnvio` loop to avoid out-of-range errors

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f793c07a88329bd014446a9ca30b4