### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Ignore build outputs
+bin/
+obj/
+packages/
+
+# Ignore binaries
+*.exe
+*.dll
+*.pdb
+
+# Ignore Visual Studio user-specific files
+*.user
+*.suo
+.vs/


### PR DESCRIPTION
## Summary
- add `.gitignore` at repository root to ignore build artifacts, binaries and user specific files

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `npm test --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6866d72c1a6083299b650121ff2809f6